### PR TITLE
lfind_test.cpp: put helpers in an anonymous namespace.

### DIFF
--- a/libc/test/src/search/lfind_test.cpp
+++ b/libc/test/src/search/lfind_test.cpp
@@ -15,7 +15,7 @@ int compar(const void *a, const void *b) {
   return *reinterpret_cast<const int *>(a) != *reinterpret_cast<const int *>(b);
 }
 
-};
+}
 
 TEST(LlvmLibcLfindTest, SearchHead) {
   int list[3] = {1, 2, 3};

--- a/libc/test/src/search/lfind_test.cpp
+++ b/libc/test/src/search/lfind_test.cpp
@@ -15,7 +15,7 @@ int compar(const void *a, const void *b) {
   return *reinterpret_cast<const int *>(a) != *reinterpret_cast<const int *>(b);
 }
 
-}
+} // namespace
 
 TEST(LlvmLibcLfindTest, SearchHead) {
   int list[3] = {1, 2, 3};

--- a/libc/test/src/search/lfind_test.cpp
+++ b/libc/test/src/search/lfind_test.cpp
@@ -9,9 +9,13 @@
 #include "src/search/lfind.h"
 #include "test/UnitTest/Test.h"
 
+namespace {
+
 int compar(const void *a, const void *b) {
   return *reinterpret_cast<const int *>(a) != *reinterpret_cast<const int *>(b);
 }
+
+};
 
 TEST(LlvmLibcLfindTest, SearchHead) {
   int list[3] = {1, 2, 3};


### PR DESCRIPTION
This matches other tests and allows the tests to be built together (as Android is doing).